### PR TITLE
Fixes for changes in API: groupCategory and ItemDetailsReport

### DIFF
--- a/src/CarbonAPI/AzureCarbonApiRetriever.cs
+++ b/src/CarbonAPI/AzureCarbonApiRetriever.cs
@@ -100,11 +100,12 @@ public class AzureCarbonApiRetriever : ICarbonRetriever
             dateRange = new { start = "2024-01-01", end = "2024-01-01" },
             orderBy = "TotalCarbonEmission",
             pageSize = 10,
-            reportType = "ItemDetailReport",
+            reportType = "ItemDetailsReport",
             resourceGroupUrlList = Array.Empty<string>(),
             sortDirection = "Asc",
             subscriptionList = subscriptions,
-            skipToken = string.Empty
+            skipToken = string.Empty,
+            groupCategory = string.Empty
         };
 
         var subscriptionWithResources = new Dictionary<string, ResourcesBySubscriptionId?>();

--- a/src/Properties/launchSettings.json
+++ b/src/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "azure-carbon-cli": {
       "commandName": "Project",
-      "commandLineArgs": "-s 2193e77b-d7ae-498b-9a28-14abbd97dfe2"
+      "commandLineArgs": "-s 2193e77b-d7ae-498b-9a28-14abbd97dfe2 --debug"
     }
   }
 }


### PR DESCRIPTION
1. Added the groupCategory as empty string, since it is now expected by the API
2. Changed the reportType from ItemDetailReport to ItemDetailsReport to accommodate for change in API